### PR TITLE
Default tabLength 1 for p8 files

### DIFF
--- a/settings/language-p8.cson
+++ b/settings/language-p8.cson
@@ -1,5 +1,6 @@
 '.source.p8':
   'editor':
+    'tabLength': 1
     'commentStart': '-- '
     'increaseIndentPattern': '\\b(else|elseif|(local\\s+)?function|then|do|repeat)\\b((?!end).)*$|\\{\\s*$'
     'decreaseIndentPattern': '^\\s*(elseif|else|end|until,?|\\}\\)?).*$'


### PR DESCRIPTION
pico-8 uses single spaces for indentation